### PR TITLE
checker improvements

### DIFF
--- a/src/main/fulcro_spec/assertions.cljc
+++ b/src/main/fulcro_spec/assertions.cljc
@@ -71,10 +71,17 @@
 
          =throws=>
          (let [cls (if cljs? :default Throwable)]
-           (if (instance? java.util.regex.Pattern expected)
+           (cond
+             (or (symbol? expected) (= :default expected))
+             `(~is (~'thrown? ~expected ~actual)
+                ~msg)
+             (instance? java.util.regex.Pattern expected)
              `(~is (~'thrown-with-msg? ~cls ~expected ~actual)
                 ~msg)
-             `(~is (~'thrown? ~expected ~actual)
+             :else
+             `(~is (~'check (fs.check/throwable* ~expected)
+                     (try ~actual
+                       (catch ~cls e# e#)))
                 ~msg)))
 
          (throw (ex-info "invalid arrow" {:arrow arrow}))))))
@@ -98,10 +105,10 @@
      (defmethod cljs.test/assert-expr 'exec [env msg form]
        `(cljs.test/do-report ~(assert-expr msg form)))
      (defmethod cljs.test/assert-expr 'check [env msg form]
-       (fs.check/check-expr msg form))
+       (fs.check/check-expr true msg form))
      (defmethod clojure.test/assert-expr '= [msg form]
        `(clojure.test/do-report ~(assert-expr msg form)))
      (defmethod clojure.test/assert-expr 'exec [msg form]
        `(clojure.test/do-report ~(assert-expr msg form)))
      (defmethod clojure.test/assert-expr 'check [msg form]
-       (fs.check/check-expr msg form))))
+       (fs.check/check-expr false msg form))))

--- a/src/main/fulcro_spec/check.cljc
+++ b/src/main/fulcro_spec/check.cljc
@@ -1,15 +1,13 @@
 (ns fulcro-spec.check
-  #?(:cljs (:require-macros [fulcro-spec.check :refer [checker]]))
+  #?(:cljs (:require-macros [fulcro-spec.check :refer [checker assert-is!]]))
   (:require
     #?@(:cljs [[goog.string.format]
-               [goog.string :refer [format]]])
-    [clojure.spec.alpha :as s]
-    [clojure.test :as t]))
+               [goog.string :as gstring]])
+    [clojure.set :as set]
+    [clojure.spec.alpha :as s]))
 
-(defn checker?
-  "Checks if passed in argument was a function created by the `checker` macro.
-   NOTE: the fact that a checker is just a fn with metadata is an internal detail, do not rely on that fact, and prefer usage of the `checker` macro."
-  [x] (and (fn? x) (::checker (meta x))))
+(defn- format-str [& args]
+  (apply #?(:cljs gstring/format :clj format) args))
 
 (defn prepend-message
   "WARNING: INTERNAL HELPER, DO NOT USE!"
@@ -18,13 +16,17 @@
     (assoc fail :message msg)
     (update fail :message (partial str msg "\n"))))
 
-(defn check-expr [msg [_ checker actual]]
-  `(let [checker# ~checker, actual# ~actual, msg# ~msg
-         location# ~(select-keys (meta checker) [:line])]
-     (if-let [failures# ((all* checker#) actual#)]
-       (doseq [f# failures#]
-         (t/do-report (merge (prepend-message msg# f#) {:type :fail} location#)))
-       (t/do-report (merge {:type :pass :message msg#} location#)))))
+(defn check-expr
+  "WARNING: FOR INTERNAL USE ONLY, DO NOT USE!"
+  [cljs? msg [_ checker actual]]
+  (let [prefix (if cljs? "cljs.test" "clojure.test")
+        do-report (symbol prefix "do-report")]
+    `(let [checker# ~checker, actual# ~actual, msg# ~msg
+           location# ~(select-keys (meta checker) [:line])]
+       (if-let [failures# ((all* checker#) actual#)]
+         (doseq [f# failures#]
+           (~do-report (merge (prepend-message msg# f#) {:type :fail} location#)))
+         (~do-report (merge {:type :pass :message msg#} location#))))))
 
 (defmacro checker
   "Creates a function that takes only one argument (usually named `actual`).
@@ -35,15 +37,35 @@
     "A checker arglist should only have one argument.")
   `(with-meta (fn ~arglist ~@args) {::checker true}))
 
+(defn checker?
+  "Checks if passed in argument was a function created by the `checker` macro.
+   NOTE: the fact that a checker is just a fn with metadata is an internal detail, do not rely on that fact, and prefer usage of the `checker` macro."
+  [x] (and (fn? x) (::checker (meta x))))
+
+(defn- assert-are-checkers! [tag checkers]
+  (doseq [c checkers]
+    (when-not (checker? c)
+      (throw (ex-info
+               (format-str "Invalid checker `%s` passed to `%s`"
+                 (pr-str c) tag)
+               {:checker c :meta (meta c) :type (type c)})))))
+
+(defmacro ^:private assert-is! [tag pred value]
+  `(when-not (~pred ~value)
+     (throw (ex-info (format-str "Invalid argument `%s` to `%s`, failed predicate `%s`"
+                       (pr-str ~value) ~tag '~pred)
+              {:predicate (str ~pred) :value ~value}))))
+
 (defn fmap*
   "Creates a new checker that is the result of applying the function to the checker arguments before passing it to the wrapped checker.
    Eg: `0 =check=> (fmap* inc (equals?* 1))`"
   [f c]
-  {:pre [(ifn? f) (checker? c)]}
+  (assert-are-checkers! `fmap* [c])
+  (assert-is! `fmap* ifn? f)
   (checker [actual]
     (c (f actual))))
 
-(defn check-failure? [x]
+(defn- check-failure? [x]
   (and (map? x)
     (or
       (contains? x :expected)
@@ -55,20 +77,37 @@
    That checker takes an `actual` argument, and calls every checker with it as the first and only argument.
    Returns nil or a sequence of maps matching `check-failure?`."
   [c & cs]
-  (doseq [c (cons c cs)]
-    (when-not (checker? c)
-      (throw (ex-info "checker should be created with `checker` macro"
-               {:checker c :meta (meta c)}))))
-  (checker [actual]
-    (->> (cons c cs)
-      (map #(% actual))
-      (flatten)
-      (filter check-failure?)
-      seq)))
+  (let [checkers (cons c cs)]
+    (assert-are-checkers! `all* checkers)
+    (checker [actual]
+      (->> (cons c cs)
+        (map #(% actual))
+        (flatten)
+        (filter check-failure?)
+        seq))))
+
+(defn and*
+  "Takes one or more `checker`s, and returns a new `checker`.
+   That checker takes an `actual` argument, and calls each checker in succession, short circuiting if any returned a `check-failure?`.
+   Returns nil or a sequence of maps matching `check-failure?`."
+  [c & cs]
+  (let [checkers (cons c cs)]
+    (assert-are-checkers! `and* checkers)
+    (checker [actual]
+      (loop [c (first checkers)
+             cs (rest checkers)]
+        (if (nil? c) nil
+          (let [?fs (c actual)
+                ?failures (if (sequential? ?fs)
+                            (flatten ?fs)
+                            (vector ?fs))]
+            (or (seq (filter check-failure? ?failures))
+              (recur (first cs) (rest cs)))))))))
 
 (defn is?*
   "Takes any truthy predicate function and returns a checker that checks with said predicate."
   [predicate]
+  (assert-is! `is?* ifn? predicate)
   (checker [actual]
     (when-not (predicate actual)
       {:actual actual
@@ -82,48 +121,113 @@
       {:actual actual
        :expected expected})))
 
+(defn- specable? [x] (or (ifn? x) (s/spec? x)))
+
 (defn valid?*
   "Takes any valid clojure.spec.alpha/spec and returns a checker.
    The checker checks with `s/valid?` and calls `s/explain-str` for the `:message`."
   [spec]
+  (assert-is! `valid?* specable? spec)
   (checker [actual]
     (when-not (s/valid? spec actual)
       {:message (s/explain-str spec actual)
        :actual actual
        :expected spec})))
 
+(defn- regex? [x]
+  (instance?
+    #?(:clj java.util.regex.Pattern
+       :cljs js/RegExp)
+    x))
+
+(defn- regexable? [x]
+  (or (string? x)
+    (regex? x)))
+
 (defn re-find?*
-  "Takes a regex (or string) and returns a checker that checks using `re-find`."
+  "Takes a regex (or string) and returns a checker that checks using `re-find`.
+   NOTE: Will first check that the incoming data (`actual`) is a `string?`"
   [regex]
-  (checker [actual]
-    (when-not (re-find regex actual)
-      {:message (format "Failed to find `%s` in '%s'" regex actual)
-       :actual actual
-       :expected `(re-pattern ~(str regex))})))
+  (assert-is! `re-find?* regexable? regex)
+  (and*
+    (is?* string?)
+    (checker [actual]
+      (when-not (re-find regex actual)
+        {:message (format-str "Failed to find `%s` in '%s'" regex actual)
+         :actual actual
+         :expected `(re-pattern ~(str regex))}))))
 
 (defn seq-matches?*
   "Takes a `sequential?` collection, and returns a checker that checks its argument in a sequential manner, ie:
    `(seq-matches?* [1 2]) =check=> [1 2]`
+
+   NOTE: does **NOT** check if the `actual` collection contains more or fewer items than expected! If not desireable, use `seq-matches-exactly?*` instead.
+
    Can also take checkers as values, eg:
    `(seq-matches?* [(is?* pos?)]) =check=> [42]`"
-  [coll]
-  (assert (sequential? coll)
-    "seq-matches?* can only take `sequential?` collections, eg: lists & vectors")
-  (all*
+  [expected]
+  (assert-is! `seq-matches?* sequential? expected)
+  (and*
+    (is?* sequential?)
     (checker [actual]
-      (assert (sequential? actual)
-        "seq-matches?* can only compare against `sequential?` collections, eg: lists & vectors")
-      (for [[idx act exp] (map vector (range) (concat actual (repeat ::not-found)) coll)]
+      (for [[idx act exp] (map vector (range) (concat actual (repeat ::not-found)) expected)]
         (cond
           (checker? exp) (exp act)
           (fn? exp) (throw (ex-info "function found, should be created with `checker` macro"
                              {:function exp :meta (meta exp)}))
           (not= act exp) {:actual act :expected exp
-                          :message (format "at index `%s` failed to match:" idx)})))))
+                          :message (format-str "at index `%s` failed to match:" idx)})))))
+
+(defn- min<=max [{:keys [min-len max-len]}] (<= min-len max-len))
+
+(defn of-length?*
+  "Checks that given `seqable?` collection has the expected length.
+   Has two arities:
+   - The first checks that the actual length is equal to the `expected-length`.
+   - The second, takes two numbers and verifies that the actual length is between (inclusively) the two numbers."
+  ([expected-length]
+   (assert-is! `of-length?* int? expected-length)
+   (and*
+     (is?* seqable?)
+     (checker [actual]
+       (let [length (count actual)]
+         (when-not (= expected-length length)
+           {:actual actual
+            :expected `(~'of-length?* :equal-to ~expected-length)
+            :message (format-str "Expected collection count to be %s was %s"
+                       expected-length length)})))))
+  ([min-len max-len]
+   (assert-is! `of-length?* int? min-len)
+   (assert-is! `of-length?* int? max-len)
+   (assert-is! `of-length?* min<=max {:min-len min-len :max-len max-len})
+   (and*
+     (is?* seqable?)
+     (checker [actual]
+       (let [length (count actual)]
+         (when-not (<= min-len length max-len)
+           {:actual actual
+            :expected `(~'of-length?* :between :min ~min-len :max ~max-len)
+            :message (format-str "Expected collection count %s to be between [%s,%s]"
+                       length min-len max-len)}))))))
+
+(defn seq-matches-exactly?*
+  "Takes a `sequential?` collection, and returns a checker that checks its argument in a sequential manner.
+   NOTE: \"exactly\" means that the `actual` collection is checked to have the **exact** same length as the `expected` collection.
+   Eg:
+   `(seq-matches?* [1 2]) =check=> [1 2]`
+   Can also take checkers as values, eg:
+   `(seq-matches?* [(is?* pos?)]) =check=> [42]`"
+  [expected]
+  (assert-is! `seq-matches-exactly?* sequential? expected)
+  (and*
+    (is?* sequential?)
+    (of-length?* (count expected))
+    (seq-matches?* expected)))
 
 (defn exists?*
   "Takes an optional failure message and returns a checker that checks for non-nil values."
   [& [msg]]
+  (when msg (assert-is! `exists?* string? msg))
   (checker [actual]
     (when-not (some? actual)
       (cond-> {:expected `some?
@@ -132,13 +236,37 @@
 
 (defn every?*
   "Takes one or more checkers, and returns a checker that runs all checker arguments on each element of the checker argument sequence.
-   WARNING: has the same semantics as `every?`, ie: will pass if given an empty collection.
-   If not desireable, use `(is?* seq)` before this checker."
+   WARNING: checks every item in the `actual` sequence, unlike `every?`.
+   WARNING: will pass if given an empty sequence, like `every?`.
+   If not desireable, compose `(is?* seq)` or `(of-length? ...)` before this checker.
+   NOTE: will short circuit execution of expected checkers using the same semantics as `and*`."
   [c & cs]
-  (checker [actual]
-    (assert (seqable? actual)
-      "every?* can only take `seqable?` collections, ie: responds to `seq`")
-    (mapcat (apply all* c cs) actual)))
+  (let [checkers (cons c cs)]
+    (assert-are-checkers! `every?* checkers)
+    (and*
+      (is?* seqable?)
+      (checker [actual]
+        (mapcat (apply and* checkers) actual)))))
+
+(defn subset?*
+  "Takes an `expected` set, and will check that `actual` contains only a subset of what is expected.
+   Eg:
+   ```
+   ; PASSES
+   #{:a} =check=> (subset?* #{:a :b})
+
+   ; FAILS
+   #{:a :b :c} =check=> (subset?* #{:a :b})
+   ```"
+  [expected]
+  (assert-is! `subset?* set? expected)
+  (and*
+    (is?* seqable?)
+    (checker [actual]
+      (when-not (set/subset? (set actual) expected)
+        {:actual {:extra-values (set/difference (set actual) expected)}
+         :expected `(~'subset?* ~expected)
+         :message "Found extra values in set"}))))
 
 (defn- path-to-get-in-failure [value path]
   (->> path
@@ -156,18 +284,21 @@
   "Takes a path and one or more checkers, and returns a checker that focuses the checker argument on the result of running `(get-in actual path)`.
    If the call to `get-in` failed it returns a `check-failure?`."
   [path c & cs]
-  (checker [actual]
-    (if-let [nested (get-in actual path)]
-      ((apply all* c cs) nested)
-      (let [missing-path (path-to-get-in-failure actual path)
-            failing-path-segment (last missing-path)
-            failing-path (vec (drop-last missing-path))]
-        {:actual actual
-         :expected `(in* ~missing-path)
-         :message (format "expected `%s` to contain `%s` at path %s"
-                     (pr-str (get-in actual failing-path))
-                     failing-path-segment
-                     (pr-str failing-path))}))))
+  (assert-is! `in* vector? path)
+  (let [checkers (cons c cs)]
+    (assert-are-checkers! `in* checkers)
+    (checker [actual]
+      (if-let [nested (get-in actual path)]
+        ((apply all* checkers) nested)
+        (let [missing-path (path-to-get-in-failure actual path)
+              failing-path-segment (last missing-path)
+              failing-path (vec (drop-last missing-path))]
+          {:actual actual
+           :expected `(in* ~missing-path)
+           :message (format-str "expected `%s` to contain `%s` at path %s"
+                      (pr-str (get-in actual failing-path))
+                      failing-path-segment
+                      (pr-str failing-path))})))))
 
 (defn append-message
   "WARNING: INTERNAL HELPER, DO NOT USE!"
@@ -190,8 +321,7 @@
    (embeds?* {:a ::not-found}) =check=> {}
    ```"
   [expected]
-  (assert (map? expected)
-    "embeds?* can only take `map?`s.")
+  (assert-is! `embeds?* map? expected)
   (letfn [(-embeds?* [expected path]
             (checker [actual]
               (for [[k v] expected]
@@ -204,9 +334,9 @@
                             :expected v
                             :message (str "at path " path ":")}
                            ((-embeds?* v path) value-at-key))
-                    (checker? v) #_=> (append-message (format "at path %s:" path)
+                    (checker? v) #_=> (append-message (format-str "at path %s:" path)
                                         ((all* v) value-at-key))
-                    (fn? v) (throw (ex-info "function found, should be created with `checker` macro"
+                    (fn? v) (throw (ex-info "Expected a checker, found a function instead!"
                                      {:function v :meta (meta v)}))
                     (and (= value-at-key ::not-found)
                       (not= v ::not-found))
@@ -218,3 +348,40 @@
                           :expected v
                           :message (str "at path " path ":")})))))]
     (-embeds?* expected [])))
+
+(defn throwable*
+  "Checks that the `actual` value is a `Throwable` (or in cljs a `js/Error`).
+   If successful, passes the `Throwable` to `all*` passed in checkers."
+  [c & cs]
+  (let [checkers (cons c cs)]
+    (assert-are-checkers! `throwable* checkers)
+    (checker [actual]
+      (if (instance? #?(:clj Throwable :cljs js/Error) actual)
+        ((apply all* checkers) actual)
+        {:actual actual
+         :expected #?(:clj Throwable :cljs js/Error)}))))
+
+(defn exception*
+  "Checks that the `actual` value is an `Exception` (or in cljs a `js/Error`).
+   If successful, passes the `Exception` to `all*` passed in checkers."
+  [c & cs]
+  (let [checkers (cons c cs)]
+    (assert-are-checkers! `exception* checkers)
+    (checker [actual]
+      (if (instance? #?(:clj Exception :cljs js/Error) actual)
+        ((apply all* checkers) actual)
+        {:actual actual
+         :expected #?(:clj Exception :cljs js/Error)}))))
+
+(defn ex-data*
+  "Checks that the `actual` value is an `ExceptionInfo`.
+  If successful, passes the `ex-data` to `all*` passed in checkers."
+  [c & cs]
+  (let [checkers (cons c cs)]
+    (assert-are-checkers! `ex-data* checkers)
+    (exception*
+      (checker [actual]
+        (if-let [data (some-> actual ex-data)]
+          ((apply all* checkers) data)
+          {:actual   actual
+           :expected ex-data})))))

--- a/src/test/fulcro_spec/assertions_spec.cljs
+++ b/src/test/fulcro_spec/assertions_spec.cljs
@@ -1,7 +1,7 @@
 (ns fulcro-spec.assertions-spec
   (:require
     [clojure.test :refer [deftest]]
-    [fulcro-spec.core :refer [specification assertions]]))
+    [fulcro-spec.core :refer [assertions]]))
 
 (deftest assert-test
   (assertions

--- a/src/test/fulcro_spec/reporters/terminal_spec.clj
+++ b/src/test/fulcro_spec/reporters/terminal_spec.clj
@@ -64,5 +64,5 @@
           (is (= "(exec 5 even?)" (find-expected-str test-5)))
           (is (= "6" (find-actual-str test-6)))
           (is (re-find #"odd_QMARK" (find-expected-str test-6)))
-          (is (= "java.lang.NullPointerException: null" (find-actual-str test-7)))
+          (is (re-find #"java.lang.NullPointerException" (find-actual-str test-7)))
           (is (= "(exec (some-> nil :fn) 7)" (find-expected-str test-7))))))))


### PR DESCRIPTION
 - adding support for using checkers in `=throws=>` assertions arrow
- adding `of-length?*`, `seq-matches-exactly?*`, and `subset?*`
- adding `and*` checker combiner, for short circuiting, instead of `all*`
- adding checks using `and*` to `seq-matches?*`, `every?*`, and `re-find?*` to first check they run against the type they expect
- adding more (& better) asserts that checkers are created correctly