### PR TITLE
check bugfixes & improvements

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -313,6 +313,98 @@ Note that you can schedule multiple things, and still return a value from the mo
 the above indicates that when `f` is called it will schedule `(g)` to run 200ms from \"now\" and `(h)` to run
 300ms from \"now\". Then `f` will return `true`.
 
+=== Check(ing)
+
+The `fulcro-spec.check` exposes functions to help make more useful and precise assertions in your tests.
+Here is a sampling of what is possible:
+
+[source]
+----
+(:require
+  [fulcro-spec.core :refer [assertions]]
+  [fulcro-spec.check :as _])
+
+(assertions
+  "equals?*"
+  1 =check=> (_/equals?* 1)
+
+  "is?*"
+  2 =check=> (_/is?* int?)
+
+  "valid?* - uses clojure.spec.alpha"
+  3 =check=> (_/valid?* int?)
+
+  "re-find?*"
+  "4" =check=> (_/re-find?* #"\d")
+
+  "seq-matches-exactly?*"
+  [5] =check=> (_/seq-matches-exactly?* [5])
+  [5 6] =check=> (_/seq-matches-exactly?*
+                   [(_/is?* int?) (_/equals?* 6)])
+
+  "every?*"
+  [7 8] =check=> (_/every?* (_/is?* int?))
+
+  "embeds?*"
+  {:a 9, :b 10}
+  =check=> (_/embeds?* {:a 9, :b (_/is?* int?)})
+
+  "throwable*"
+  (throw (ex-info "" {}))
+  =throws=> (_/throwable* (_/is?* some?))
+
+  "ex-data*"
+  (throw (ex-info "" {:c 11}))
+  =throws=> (_/ex-data* (_/equals?* {:c 11})))
+----
+
+You can make your own checkers using the `_/checker` macro.
+They are simply functions that are expected to conditionally return maps each representing a failed assertion.
+
+[source]
+----
+(defn my-equals?* [expected]
+  (_/checker [actual]
+    (when-not (= actual expected) ;; <1>
+      {:actual actual ;; <2> <3> <4>
+       :expected expected
+       :message "my-equals?* failed!"})))
+
+((my-equals?* 55) 33)
+;=> {:actual 33 :expected 55 ,,,}
+----
+
+<1> nil or an empty sequence is considered passing.
+<2> A checker can return a single failure, or many (arbitrarily nested, as will be `flatten` -ed by the `=check=>` arrow).
+<3> Note that for a map to be considered a failure, it must contain one of the following keys `#{:actual :expected :message :type}`.
+<4> The shown map keys are what `clojure.test` understands, but it is an open map that you can extend. When in an `assertions` macro all failures will sent to the current `clojure.test` reporter, but there are no guarantees that it will be understood or reported by it.
+
+==== Advanced usage
+
+To combine multiple checkers into a single assertion, two functions are provided.
+The first is `all*`, and it will run all it's checkers.
+The second is `and*`, it will short circuit execution on the first failure. Note that because checkers can return multiple failures, it is not guaranteed that `and*` will return only a single failure.
+
+[source]
+----
+(assertions
+  ((all* (_/equals?* 1) (_/is?* int?)) 5.0)
+  => [{:actual 5.0 :expected 1}
+      {:actual 5.0 :expected int?}]
+
+  ((and* (_/is?* int?) (_/equals?* 1)) 5.0)
+  => {:actual 5.0 :expected int?})
+----
+
+It can be useful to run a function on a value before passed to a checker, such as sorting.
+For this you can use `fmap*`, but use it judiciously, as you can perform arbitrary transformations that may make your test failures harder to understand.
+
+[source]
+----
+(assertions
+  [:c :a :b] => (_/fmap* sort (_/equals [:a :b :c])))
+----
+
 == REPL Usage (Clojure)
 
 The terminal reporter is quite easy and useful to use at the REPL for Clojure. Simply start a REPL, and define a keyboard shortcut to run something like this:

--- a/src/main/fulcro_spec/assertions.cljc
+++ b/src/main/fulcro_spec/assertions.cljc
@@ -8,7 +8,8 @@
     #?(:clj
        [fulcro-spec.impl.macros :as im])
     [fulcro-spec.spec :as fss]
-    [fulcro-spec.check :as fs.check]))
+    [fulcro-spec.check :as fs.check]
+    [fulcro-spec.impl.check :as fs.impl.check]))
 
 (s/def ::arrow (comp #{"=>" "=fn=>" "=throws=>" "=check=>"} str))
 (s/def ::behavior string?)
@@ -105,10 +106,10 @@
      (defmethod cljs.test/assert-expr 'exec [env msg form]
        `(cljs.test/do-report ~(assert-expr msg form)))
      (defmethod cljs.test/assert-expr 'check [env msg form]
-       (fs.check/check-expr true msg form))
+       (fs.impl.check/check-expr true msg form))
      (defmethod clojure.test/assert-expr '= [msg form]
        `(clojure.test/do-report ~(assert-expr msg form)))
      (defmethod clojure.test/assert-expr 'exec [msg form]
        `(clojure.test/do-report ~(assert-expr msg form)))
      (defmethod clojure.test/assert-expr 'check [msg form]
-       (fs.check/check-expr false msg form))))
+       (fs.impl.check/check-expr false msg form))))

--- a/src/main/fulcro_spec/impl/check.cljc
+++ b/src/main/fulcro_spec/impl/check.cljc
@@ -1,0 +1,35 @@
+(ns fulcro-spec.impl.check
+  #?(:cljs (:require
+             [goog.string.format]
+             [goog.string :as gstring])))
+
+(defn format-str [& args]
+  (apply #?(:cljs gstring/format :clj format) args))
+
+(defn prepend-message [msg fail]
+  (if-not (:message fail)
+    (assoc fail :message msg)
+    (update fail :message (partial str msg "\n"))))
+
+(defn append-message [message failure]
+  (update failure :message
+    (fn [msg]
+      (if-not msg message
+        (str msg "\n" message)))))
+
+(defn failure->report [test-msg failure actual]
+  (merge {:type :fail :fulcro-spec.check/actual actual}
+    (cond->> (prepend-message test-msg failure)
+      (::path failure)
+      (append-message
+        (str "at path " (::path failure) ":")))))
+
+(defn check-expr [cljs? msg [_ checker actual]]
+  (let [prefix (if cljs? "cljs.test" "clojure.test")
+        do-report (symbol prefix "do-report")]
+    `(let [checker# ~checker, actual# ~actual, msg# ~msg
+           location# ~(select-keys (meta checker) [:line])]
+       (if-let [failures# ((fulcro-spec.check/all* checker#) actual#)]
+         (doseq [f# failures#]
+           (~do-report (merge (failure->report msg# f# actual#) location#)))
+         (~do-report (merge {:type :pass :message msg#} location#))))))


### PR DESCRIPTION
- fixing `embeds?*` and `in*` path reporting
- adding the original/root actual value to all checker failures (eg: to help when using `embeds?*`)
- making public the checker assertion helpers `assert-is!` and `assert-are-checkers!`
- cleaning check API: using an impl ns for internal functions

- adding experimental checkers `behavior*` and `with-message*`