### PR TITLE
Fix possible typo in usage example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -95,7 +95,7 @@ NOTE: Be sure to check "Before Executing" -> "Load File" on the REPL command.
     ...))
 
 (defn f [x] 900)
-(defn g [y] (f y))
+(defn g [y] (+ y (f y)))
 
 (deftest my-test
   (when-mocking


### PR DESCRIPTION
The test in the usage example on the README fails when run. This change makes it pass.